### PR TITLE
Added TwinWeaver reference

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -17,6 +17,8 @@ This organization contains GitHub Repositories for the _Medical Event Data Stand
 | FEMR            | Package |                                                        | [GitHub](https://github.com/som-shahlab/femr)             |                                    | A Python package for manipulating longitudinal EHR data for machine learning, with a focus on supporting the creation of foundation models and verifying their presumed benefits in healthcare. |
 | MEDS-DEV | Benchmark |  | [GitHub](https://github.com/mmcdermott/MEDS-DEV) | | A benchmark for evaluating the performance of machine learning models on MEDS-formatted data. |    
 | MEDS-Inspect | Package |  | [GitHub](https://github.com/rvandewater/MEDS-Inspect) | | A package to interactively inspect your MEDS data. |    
+| TwinWeaver      | Package | [Docs](https://mendenlab.github.io/TwinWeaver/)   | [GitHub](https://github.com/MendenLab/TwinWeaver)         | [arXiv](https://arxiv.org/abs/2601.20906) | Package for training & evaluating LLMs on longitudinal clinical data. |
+
 
 ## Pretrained Models
   * CLMBR-T-base: https://huggingface.co/StanfordShahLab/clmbr-t-base

--- a/profile/README.md
+++ b/profile/README.md
@@ -17,7 +17,7 @@ This organization contains GitHub Repositories for the _Medical Event Data Stand
 | FEMR            | Package |                                                        | [GitHub](https://github.com/som-shahlab/femr)             |                                    | A Python package for manipulating longitudinal EHR data for machine learning, with a focus on supporting the creation of foundation models and verifying their presumed benefits in healthcare. |
 | MEDS-DEV | Benchmark |  | [GitHub](https://github.com/mmcdermott/MEDS-DEV) | | A benchmark for evaluating the performance of machine learning models on MEDS-formatted data. |    
 | MEDS-Inspect | Package |  | [GitHub](https://github.com/rvandewater/MEDS-Inspect) | | A package to interactively inspect your MEDS data. |    
-| TwinWeaver      | Package | [Docs](https://mendenlab.github.io/TwinWeaver/)   | [GitHub](https://github.com/MendenLab/TwinWeaver)         | [arXiv](https://arxiv.org/abs/2601.20906) | Package for training & evaluating LLMs on longitudinal clinical data. |
+| TwinWeaver      | Package | [Docs](https://mendenlab.github.io/TwinWeaver/)   | [GitHub](https://github.com/MendenLab/TwinWeaver)         | [arXiv](https://arxiv.org/abs/2601.20906) | A package for training & evaluating LLMs on longitudinal clinical data. |
 
 
 ## Pretrained Models


### PR DESCRIPTION
We recently released TwinWeaver (https://github.com/MendenLab/TwinWeaver), a framework for training LLMs using longitudinal medical data.

We included functions as well as a tutorial ([linked here](https://github.com/MendenLab/TwinWeaver/blob/main/examples/integrations/meds_data_import.ipynb)) on importing MEDS data.

Following the (discussion on the main MEDS repo)[https://github.com/Medical-Event-Data-Standard/meds/issues/104], here is the PR. 

Please let me know if anyting needs changing.